### PR TITLE
Fix client side bug during import

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -190,6 +190,7 @@ def _importTar(self, assetstore, folder, path, progress):
 
 
 def load(info):
+    # TODO allow a file to be stored in multiple tape archive assetstores
     setAssetstoreAdapter(AssetstoreType.FILESYSTEM, TarSupportAdapter)
 
     info['apiRoot'].assetstore.route('POST', (':id', 'tar_export'), _exportTar)

--- a/web_client/main.js
+++ b/web_client/main.js
@@ -26,7 +26,7 @@ FilesystemImportView.prototype.events['click .g-tape-archive-import'] = function
         type: 'POST',
         url: `assetstore/${this.assetstore.id}/tar_import`,
         data: {
-            folderId: this.$('#g-filesystem-import-dest-id').val(),
+            folderId: this.$('#g-filesystem-import-dest-id').val().split(' ')[0],
             path: this.$('#g-filesystem-import-path').val(),
             progress: true
         },


### PR DESCRIPTION
https://github.com/girder/girder/commit/1b031a34454bae67cd3e91f4958cd2aa7af1cd23 caused extra information to be appended to the browser
text field. This ignores that extra info to pass just the ObjectId
of the destination. This is similar to the way it's done in the
FilesystemImportView in core.