### PR TITLE
Bump version to 3.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 # perform the install
 setup(
     name='girder-tape-archive',
-    version='1.0.0',
+    version='3.0.0',
     description='Adds support to filesystem assetstores for storing Girder files within compressed or '
                 'uncompressed tape archive (TAR) files via import and export processes.',
     maintainer='Kitware, Inc.',


### PR DESCRIPTION
PyPI claims that 1.0.0 already exists, even though I don't see it
on the registry.